### PR TITLE
Fix typo in name of is_templatevm function

### DIFF
--- a/vm-boot-protect.sh
+++ b/vm-boot-protect.sh
@@ -90,7 +90,7 @@ if ! is_rwonly_persistent; then
     if qsvc vm-boot-protect; then
         make_immutable
     fi
-    if ! is_template_vm; then
+    if ! is_templatevm; then
         # Keep configs invisible for standalone vms
         rm -rf "$defdir"
     fi


### PR DESCRIPTION
There appears to be a typo in the is_templatevm function from /usr/lib/qubes/init/functions. This breaks the whitelisting functionality by deleting $defdirs in the template vm.